### PR TITLE
Update server.port to 5000 for AWS in application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.jpa.hibernate.ddl-auto=update
 
 
 #AWS default port is 5000
-#server.port=5000
+server.port=5000
 
 
 


### PR DESCRIPTION
To deploy on the aws, server.port should be changed to 5000.
This is because Elastic Beanstalk's default configuration assumes that the application will be listening on port 5000.